### PR TITLE
[Merged by Bors] - Use stable clippy & rustfmt when nightly fails

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,8 +32,8 @@ branches:
     - master
 
 before_install:
-  - rustup component add clippy
-  - rustup component add rustfmt
+  - rustup component add clippy || rustup +stable component add clippy
+  - rustup component add rustfmt || rustup +stable component add rustfmt
 
 script:
   - cargo fmt --verbose -- --verbose --check


### PR DESCRIPTION
Clippy and rustfmt often don't have downloads available in nightly, causing nightly CI builds to fail prematurely. Stable versions of these tools are now used as backup in case nightly versions are not available. The stable versions will run even if the nightly version is available and fails legitimately, however, but there is really no drawback here since the stable/beta builds will fail as well.