### PR TITLE
[Merged by Bors] - Use idiomatic use paths

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -8,13 +8,13 @@ use amethyst::{
         types::DefaultBackend,
         RenderingBundle,
     },
-    utils::application_root_dir,
+    utils,
 };
 
 fn main() -> amethyst::Result<()> {
     amethyst::start_logger(Default::default());
 
-    let app_root = application_root_dir()?;
+    let app_root = utils::application_root_dir()?;
 
     let assets_dir = app_root.join("assets");
     let config_dir = app_root.join("config");


### PR DESCRIPTION
These aren't official guidelines, but consistency is key to maintainability.
See [this part](https://doc.rust-lang.org/stable/book/ch07-04-bringing-paths-into-scope-with-the-use-keyword.html#creating-idiomatic-use-paths) of the Rust book for more info.