### PR TITLE
[Merged by Bors] - Fix 4a9308d: "Use stable clippy & rustfmt when nightly fails (#5)"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,13 +34,13 @@ branches:
     - trying
     - master
 
-before_install:
-  - rustup component add clippy || rustup +stable component add clippy
-  - rustup component add rustfmt || rustup +stable component add rustfmt
+before_script:
+  - rustup +stable component add clippy
+  - rustup +stable component add rustfmt
 
 script:
-  - cargo fmt --verbose -- --verbose --check
-  - cargo clippy --verbose --features $GRAPHICAL_BACKEND
+  - cargo +stable fmt --verbose -- --verbose --check
+  - cargo +stable clippy --verbose --features $GRAPHICAL_BACKEND
   - cargo build --verbose --features $GRAPHICAL_BACKEND
   - cargo test --verbose --features $GRAPHICAL_BACKEND
 


### PR DESCRIPTION
4a9308d attempted to solve the problem of nightly sometimes not having
clippy or rustfmt available by installing the stable versions of these
tools as a backup. What it neglected to address was that the `cargo
clippy` and `cargo fmt` commands used *didn't try to use the stable
versions on nightly toolchains*, rendering 4a9308d effectively
uneffective. Fancy that.

This commit *always* uses the stable versions of clippy and rustfmt on
*all* toolchains to prevent errors. We don't need to test nightly rust
tools; we need to test this repository.

The `before_install` section was changed to `before_script` as well to
reflect when the clippy and rustfmt installs are actually needed.