### PR TITLE
[Merged by Bors] - Enforce Unix newlines through rustfmt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,3 +51,6 @@ addons:
       - libasound2-dev
       - libxcb-shape0-dev
       - libxcb-xfixes0-dev
+
+git:
+  autocrlf: input

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,3 +1,4 @@
 edition = "2018"
+newline_style = "Unix"
 use_field_init_shorthand = true
 use_try_shorthand = true


### PR DESCRIPTION
This was previously done before 5984e0d: "Add integration tests for macOS and Windows (#2)", which (so I thought) forced a change due to Travis's repository cloning on Windows changing the newline style, causing rustfmt to fail on Windows consistently. Newline conversions on clone can be disabled according to [the Travis docs](https://docs.travis-ci.com/user/customizing-the-build/#git-end-of-line-conversion-control), allowing for enforcement of Unix newlines once again.