### PR TITLE
Don't build the master branch on CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,6 @@ branches:
   only:
     - staging
     - trying
-    - master
 
 before_script:
   - rustup +stable component add clippy


### PR DESCRIPTION
Bors already tests integration into the master branch, and Travis
already tests pull requests. Doing a branch test on master is thus
redundant.