### PR TITLE
[Merged by Bors] - Partially revert 59f2b3b to comply with Travis docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ branches:
     - trying
     - master
 
-before_script:
+before_install:
   - rustup +stable component add clippy
   - rustup +stable component add rustfmt
 


### PR DESCRIPTION
The [Travis CI docs](https://docs.travis-ci.com/user/languages/rust/#choosing-a-rust-version) say to use the `before_install` section to install tools like clippy and rustfmt, and errors were encountered after changing it to `before_script`.