### PR TITLE
[Merged by Bors] - Require Cargo.lock to be up-to-date in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ before_install:
 script:
   - cargo +stable fmt --verbose -- --verbose --check
   - cargo +stable clippy --verbose --features $GRAPHICAL_BACKEND
-  - cargo build --verbose --features $GRAPHICAL_BACKEND
+  - cargo build --locked --verbose --features $GRAPHICAL_BACKEND
   - cargo test --verbose --features $GRAPHICAL_BACKEND
 
 addons:


### PR DESCRIPTION
This prevents accidentally not updating Cargo.lock after a change/update in dependencies.