### PR TITLE
[Merged by Bors] - Enforce stricter linting across rustc and clippy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,28 @@ os:
 
 env:
   global:
-    - RUSTFLAGS="-D warnings"
+    - RUSTFLAGS="
+      -D absolute-paths-not-starting-with-crate
+      -D anonymous-parameters
+      -D deprecated-in-future
+      -D elided-lifetimes-in-paths
+      -D explicit-outlives-requirements
+      -D indirect-structural-match
+      -D keyword-idents
+      -D macro-use-extern-crate
+      -D missing-docs
+      -D missing-doc-code-examples
+      -D non-ascii-idents
+      -D private-doc-tests
+      -D trivial-casts
+      -D trivial-numeric-casts
+      -D unreachable-pub
+      -D unused-extern-crates
+      -D unused-import-braces
+      -D unused-lifetimes
+      -D unused-results
+      -D variant-size-differences
+      -D warnings"
   jobs:
     - GRAPHICAL_BACKEND=metal
     - GRAPHICAL_BACKEND=vulkan
@@ -40,7 +61,65 @@ before_install:
 
 script:
   - cargo +nightly-2020-03-22 fmt --verbose -- --verbose --check
-  - cargo +stable clippy --verbose --features $GRAPHICAL_BACKEND
+  - cargo +stable clippy --verbose --features $GRAPHICAL_BACKEND --
+    -D clippy::as_conversions
+    -D clippy::cast_lossless
+    -D clippy::cast_possible_truncation
+    -D clippy::cast_possible_wrap
+    -D clippy::cast_sign_loss
+    -D clippy::checked_conversions
+    -D clippy::clone_on_ref_ptr
+    -D clippy::copy_iterator
+    -D clippy::dbg_macro
+    -D clippy::decimal_literal_representation
+    -D clippy::default_trait_access
+    -D clippy::else_if_without_else
+    -D clippy::empty_enum
+    -D clippy::enum_glob_use
+    -D clippy::exit
+    -D clippy::explicit_into_iter_loop
+    -D clippy::explicit_iter_loop
+    -D clippy::filter_map_next
+    -D clippy::if_not_else
+    -D clippy::inline_always
+    -D clippy::integer_division
+    -D clippy::large_digit_groups
+    -D clippy::map_flatten
+    -D clippy::mem_forget
+    -D clippy::missing_docs_in_private_items
+    -D clippy::missing_errors_doc
+    -D clippy::module_name_repetitions
+    -D clippy::multiple_inherent_impl
+    -D clippy::mut_mut
+    -D clippy::needless_continue
+    -D clippy::option_expect_used
+    -D clippy::option_map_unwrap_or
+    -D clippy::option_map_unwrap_or_else
+    -D clippy::option_unwrap_used
+    -D clippy::panic
+    -D clippy::print_stdout
+    -D clippy::pub_enum_variant_names
+    -D clippy::result_expect_used
+    -D clippy::result_map_unwrap_or_else
+    -D clippy::result_unwrap_used
+    -D clippy::same_functions_in_if_condition
+    -D clippy::shadow_reuse
+    -D clippy::shadow_same
+    -D clippy::shadow_unrelated
+    -D clippy::single_match_else
+    -D clippy::string_add
+    -D clippy::string_add_assign
+    -D clippy::todo
+    -D clippy::type_repetition_in_bounds
+    -D clippy::unicode_not_nfc
+    -D clippy::unimplemented
+    -D clippy::unneeded_field_pattern
+    -D clippy::unreachable
+    -D clippy::unseparated_literal_suffix
+    -D clippy::unused_self
+    -D clippy::used_underscore_binding
+    -D clippy::wildcard_dependencies
+    -D clippy::wrong_pub_self_convention
   - cargo build --locked --verbose --features $GRAPHICAL_BACKEND
   - cargo test --verbose --features $GRAPHICAL_BACKEND
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,10 @@
+//! `work_in_progress` (final name TBD) is my personal attempt at creating
+//! something using the [Amethyst game engine][ge]. It has no definite goals at
+//! the moment, but currently strives for clear, idiomatic code and a robust
+//! testing system to ensure quality for future users and contributors.
+//!
+//! [ge]: https://amethyst.rs
+
 mod states;
 
 use amethyst::{
@@ -9,10 +16,11 @@ use amethyst::{
         RenderingBundle,
     },
     utils,
+    LoggerConfig,
 };
 
 fn main() -> amethyst::Result<()> {
-    amethyst::start_logger(Default::default());
+    amethyst::start_logger(LoggerConfig::default());
 
     let app_root = utils::application_root_dir()?;
 

--- a/src/states/ingame.rs
+++ b/src/states/ingame.rs
@@ -1,6 +1,9 @@
+//! The main gameplay state
+
 use super::state_prelude::*;
 
-pub struct Ingame;
+/// The struct implementing the main gameplay state
+pub(crate) struct Ingame;
 
 impl SimpleState for Ingame {
     fn on_start(&mut self, _data: StateData<'_, GameData<'_, '_>>) {}

--- a/src/states/mod.rs
+++ b/src/states/mod.rs
@@ -1,7 +1,12 @@
-pub mod state_prelude {
-    pub use amethyst::{GameData, SimpleState, StateData};
+//! The collection of possible game states
+
+/// Contains common types used when implememnting a [`State`]
+///
+/// [`State`]: https://docs.amethyst.rs/stable/amethyst/trait.State.html
+mod state_prelude {
+    pub(super) use amethyst::{GameData, SimpleState, StateData};
 }
 
-pub use ingame::Ingame;
+pub(crate) use ingame::Ingame;
 
 mod ingame;


### PR DESCRIPTION
My strategy here is essentially this:

_Enable every lint which catches something I deem potentially "bad", and explicitly bypass them on a case-by-case basis._

This should ease _my_ maintenance code-style-wise, plus keep code as consistent as possible across the board. _I also prefer being explicit over being implicit, **except** when it unnecessarily increases verbosity_.

These statements should be included in a CONTRIBUTING.md as well once I find the time to write one.